### PR TITLE
Add a bulk constructor to the ResourceLinker

### DIFF
--- a/WebApi.Hal/ResourceLinker.cs
+++ b/WebApi.Hal/ResourceLinker.cs
@@ -9,6 +9,16 @@ namespace WebApi.Hal
     {
         readonly Dictionary<Type, object> resourceLinkers = new Dictionary<Type, object>();
 
+        public ResourceLinker() 
+        {
+
+        }
+
+        public ResourceLinker(Dictionary<Type, object> resourceLinkers)
+        {
+            this.resourceLinkers= resourceLinkers;
+        }
+
         public void AddLinker<T>(IResourceLinker<T> resourceLinker)
         {
             var type = typeof(T);


### PR DESCRIPTION
Hi, I'm currently experimenting with options for HATEOAS components for my RESTful API ;) , so have been taking a looksy at your implementation of JSON+Hal.

I use Spring as my IoC container and struggled to configure your 'ResourceLinker' class effectively in my environment. 

To combat this I added a fairly brutal new constructor to the class to allow all the resource linkers to be specified up front, in theory that might be useful to others too :) 

Example config looks like  this :

```
<object id="ResourceLinker" type="WebApi.Hal.ResourceLinker" singleton="true" lazy-init="true">
  <constructor-arg>
    <dictionary key-type="System.Type" value-type="System.Object">
      <entry value-ref="AppleLinker"><key><expression value="T(MyAPI.Resources.AppleResource)"/></key> </entry>
    </dictionary>
  </constructor-arg>    
</object>
```

Hope it helps.   
