### PR TITLE
Fixed LINQ Brewery issue.

### DIFF
--- a/WebApi.Hal.Web/Api/BreweriesController.cs
+++ b/WebApi.Hal.Web/Api/BreweriesController.cs
@@ -20,11 +20,7 @@ namespace WebApi.Hal.Web.Api
                 .Select(s => new BreweryRepresentation
                 {
                     Id = s.Id,
-                    Name = s.Name,
-                    Links =
-                    {
-                        LinkTemplates.Breweries.AssociatedBeers.CreateLink(new { s.Id })
-                    }
+                    Name = s.Name
                 })
                 .ToList();
 
@@ -38,11 +34,7 @@ namespace WebApi.Hal.Web.Api
             return new BreweryRepresentation
             {
                 Id = brewery.Id,
-                Name = brewery.Name,
-                Links =
-                {
-                    LinkTemplates.Breweries.AssociatedBeers.CreateLink(new { id })
-                }
+                Name = brewery.Name
             };
         }
     }

--- a/WebApi.Hal.Web/Api/Resources/BreweryRepresentation.cs
+++ b/WebApi.Hal.Web/Api/Resources/BreweryRepresentation.cs
@@ -11,6 +11,8 @@ namespace WebApi.Hal.Web.Api.Resources
             var selfLink = LinkTemplates.Breweries.Brewery.CreateLink(new{Id});
             Href = selfLink.Href;
             Rel = selfLink.Rel;
+
+            LinkTemplates.Breweries.AssociatedBeers.CreateLink(new { Id });
         }
     }
 }


### PR DESCRIPTION
Fixed the 'In constructors and initializers, only property or field parameter bindings are supported in LINQ to Entities.' by moving brewery associated link creation from the controller to the representation.

Issue 14.
