### PR TITLE
Fixed for LINQ query error in BreweriesController

### DIFF
--- a/WebApi.Hal.Web/Api/BreweriesController.cs
+++ b/WebApi.Hal.Web/Api/BreweriesController.cs
@@ -17,6 +17,7 @@ namespace WebApi.Hal.Web.Api
         public BreweryListRepresentation Get()
         {
             var breweries = beerDbContext.Styles
+                .ToList()
                 .Select(s => new BreweryRepresentation
                 {
                     Id = s.Id,


### PR DESCRIPTION
Fixed the 'In constructors and initializers, only property or field parameter bindings are supported in LINQ to Entities.'
