### PR TITLE
Make a Representation re-serializable

### DIFF
--- a/WebApi.Hal/Representation.cs
+++ b/WebApi.Hal/Representation.cs
@@ -25,6 +25,9 @@ namespace WebApi.Hal
         [OnSerializing]
         private void OnSerialize(StreamingContext context)
         {
+            // Clear the embeddedResourceProperties in order to make this object re-serializable.
+            embeddedResourceProperties.Clear();
+
             RepopulateHyperMedia();
 
             if (ResourceConverter.IsResourceConverterContext(context))


### PR DESCRIPTION
Ran into a problem when caching Representations.

When pulling a Representation from cache, embeddedResourceProperties is already populated with properties and values.  This means a second call to OnSerialize will fail if the embeddedResourceProperties dictionary isn't cleared.
