### PR TITLE
maintain title of templated link when creating a non-templated version

### DIFF
--- a/WebApi.Hal.Tests/UriBuilderTests.cs
+++ b/WebApi.Hal.Tests/UriBuilderTests.cs
@@ -111,5 +111,18 @@ namespace WebApi.Hal.Tests
             // assert
             Assert.Equal("http://myserver.com/api/beers/BeerName", link.ToString());
         }
+
+        [Fact]
+        public void create_link_uses_templates_title()
+        {
+            // arrange
+            var templateLink = new Link("beerbyname", "http://myserver.com/api/beers{name}", "Beer");
+
+            // act
+            var link = templateLink.CreateLink(new {name = "BeerName"});
+
+            // assert
+            Assert.Equal(link.Title, "Beer");
+        }
     }
 }

--- a/WebApi.Hal/Link.cs
+++ b/WebApi.Hal/Link.cs
@@ -34,7 +34,7 @@ namespace WebApi.Hal
         /// <returns>A non templated link</returns>
         public Link CreateLink(string newRel, params object[] parameters)
         {
-            return new Link(newRel, CreateUri(parameters).ToString());
+            return new Link(newRel, CreateUri(parameters).ToString(), Title);
         }
 
         /// <summary>


### PR DESCRIPTION
We have a use case where we'd like it to maintain the title of the templated link.  I'm not sure if this is a omission of there's a use case you're thinking of where it shouldn't?

Thanks,
Tom
