### PR TITLE
Make ResolveUri virtual

### DIFF
--- a/WebApi.Hal/JsonConverters/LinksConverter.cs
+++ b/WebApi.Hal/JsonConverters/LinksConverter.cs
@@ -93,7 +93,7 @@ namespace WebApi.Hal.JsonConverters
             return typeof(IList<Link>).IsAssignableFrom(objectType);
         }
 
-        public string ResolveUri(string href)
+        public virtual string ResolveUri(string href)
         {
             if (!string.IsNullOrEmpty(href) && VirtualPathUtility.IsAppRelative(href))
                 return HttpContext.Current != null ? VirtualPathUtility.ToAbsolute(href) : href.Replace("~/", "/");


### PR DESCRIPTION
I would like to be able to override this property to provide a full URI, including the scheme and authority.

The merits of doing this, vs providing relative paths can be debated (http://stackoverflow.com/a/18505331), which is why I'm not suggesting changing how this is handled here.