### PR TITLE
Remove WebApi.Hal package dependency on Microsoft.AspNet.WebApi

### DIFF
--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -47,14 +47,6 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.1.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/WebApi.Hal/packages.config
+++ b/WebApi.Hal/packages.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi" version="5.1.2" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net451" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
And by extension, Microsoft.AspNet.WebApi.WebHost and Microsoft.AspNet.WebApi.Core.
Microsoft.AspNet.WebApi.Client remains, for the media formatters. This should allow cleaner integration with Owin and other non-IIS platforms.