### PR TITLE
Support IEnumerable and IDictionary parameter values in "Uri CreateUr…

### DIFF
--- a/WebApi.Hal/Link.cs
+++ b/WebApi.Hal/Link.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.Linq;
 using WebApi.Hal.Interfaces;
+using System.Collections;
 
 namespace WebApi.Hal
 {
@@ -131,8 +133,32 @@ namespace WebApi.Hal
                 {
                     var name = substitution.Name;
                     var value = substitution.GetValue(parameter, null);
-                    var substituionValue = value == null ? null : value.ToString();
-                    uriTemplate.SetParameter(name, substituionValue);
+                    if (value == null)
+                    {
+                        // Skip
+                    }
+                    else if (value is string)
+                    {
+                        uriTemplate.SetParameter(name, value);
+                    }
+                    else if (value is System.Collections.IEnumerable)
+                    {
+                        if (value is System.Collections.IDictionary)
+                        {
+                            var substitutionValue = ((value) as IEnumerable).Cast<DictionaryEntry>().ToDictionary(x => x.Key.ToString(), x => x.Value.ToString());
+                            uriTemplate.SetParameter(name, substitutionValue);
+                        }
+                        else
+                        {
+                            var substitutionValue = ((value) as IEnumerable).Cast<object>().Select(x => x.ToString());
+                            uriTemplate.SetParameter(name, substitutionValue);
+                        }
+                    }
+                    else
+                    {
+                        var substitutionValue = value.ToString();
+                        uriTemplate.SetParameter(name, substitutionValue);
+                    }
                 }
             }
 


### PR DESCRIPTION
Passing a string array (IEnumerable) as one item in the "parameters" argument to "Link.CreateUri(params object[] parameters)" does not work (although the underlying UriTemplate class supports it in its parameters list).
This is needed when constructing urls for web.api which can contain arrays in the query part (the same query parameter occuring multiple times, e.g. http://myhost/with/some/path?tag=bla&tag=blub).

In Link.SubstituteParams all values are converted to strings with ToString() so all arrays are converted to single values (e.g. "System.String[]").

Enumerables should be passed as Enumerables to the UriTemplate class (and only the items converted to strings where necessary).

The same happens with Dictionaries (UriTemplate supports IDictionary).
