### PR TITLE
Corrected Percent Encoding of URIs

### DIFF
--- a/WebApi.Hal/Link.cs
+++ b/WebApi.Hal/Link.cs
@@ -99,7 +99,7 @@ namespace WebApi.Hal
             var clone = Clone();
 
             clone.Rel = newRel;
-            clone.Href = CreateUri(parameters).ToString();
+            clone.Href = CreateUri(parameters).AbsoluteUri;
 
             return clone;
         }


### PR DESCRIPTION
Some special characters in URI template parameters are not encoded properly. It is expected, that all special characters, including spaces, are percent encoded. The method Uri.ToString() just returns a canonical representation of a URI, which is not necessarily encoded correctly. However Uri.AbsoluteUri returns a properly encoded URI.

This refers to issue https://github.com/JakeGinnivan/WebApi.Hal/issues/132