### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Licence.md
+++ b/Licence.md
@@ -1,4 +1,4 @@
-###Microsoft Public License (MS-PL)
+### Microsoft Public License (MS-PL)
 
 This license governs use of the accompanying software. If you use the software, you
 accept this license. If you do not accept the license, do not use the software.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To run the sample project, update the connection string in web.config, then **cr
 
 You can use fiddler to explore the API. Make sure you put in an accept header of `application/hal+json`. Try hitting `http://localhost:51665/beers` with that accept header, and see what happens
 
-##Credits
+## Credits
 I have more credits to add, but this is the most obvious (as I based my Xml formatter off this project)
 
 https://bitbucket.org/smichelotti/hal-media-type


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
