### PR TITLE
Fix variable expansion in CreateLink

### DIFF
--- a/WebApi.Hal.Tests/UriBuilderTests.cs
+++ b/WebApi.Hal.Tests/UriBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Collections.Generic;
+using Xunit;
 
 namespace WebApi.Hal.Tests
 {
@@ -57,6 +58,45 @@ namespace WebApi.Hal.Tests
             Assert.Equal("/beers?searchTerm=test", link.Href);
         }
 
+        [Fact]
+        public void create_link_handles_expansion()
+        {
+            // arrange
+            var templateLink = new Link("beers", "/beers{?searchTerm}");
+
+            // act
+            var link = templateLink.CreateLink(new {searchTerm = new[] {"test1", "test2"}});
+
+            // assert
+            Assert.Equal("/beers?searchTerm=test1,test2", link.Href);
+        }
+
+        [Fact]
+        public void create_link_handles_expansion2()
+        {
+            // arrange
+            var templateLink = new Link("beers", "/beers{?searchTerm*}");
+
+            // act
+            var link = templateLink.CreateLink(new {searchTerm = new[] {"test1", "test2"}});
+
+            // assert
+            Assert.Equal("/beers?searchTerm=test1&searchTerm=test2", link.Href);
+        }
+
+        [Fact]
+        public void create_link_handles_non_string_objects()
+        {
+            // arrange
+            var templateLink = new Link("beers", "/beers{?searchTerm}");
+
+            // act
+            var link = templateLink.CreateLink(new {searchTerm = new object()});
+
+            // assert somewhat useless behaviour
+            Assert.Equal("/beers?searchTerm=System.Object", link.Href);
+        }
+        
         [Fact]
         public void create_link_handles_spaces()
         {

--- a/WebApi.Hal/Link.cs
+++ b/WebApi.Hal/Link.cs
@@ -131,8 +131,7 @@ namespace WebApi.Hal
                 {
                     var name = substitution.Name;
                     var value = substitution.GetValue(parameter, null);
-                    var substituionValue = value == null ? null : value.ToString();
-                    uriTemplate.SetParameter(name, substituionValue);
+                    uriTemplate.SetParameter(name, value);
                 }
             }
 


### PR DESCRIPTION
Pass data in as-is, instead of calling .ToString() to allow enumerable and dictionary handling

Simplified the URI template class to reduce nesting and treat all objects not otherwise handled as a string

Added unit tests for a bit more of the bizzare behaviour when using invalid data, so at least we know it's happening