### PR TITLE
Fix encoding when resolving templated URIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ _ReSharper*
 # NCrunch
 .*crunch*.local.xml
 
+# Rider
+.idea/
+
 # Installshield output folder 
 [Ee]xpress
 

--- a/WebApi.Hal.Tests/UriBuilderTests.cs
+++ b/WebApi.Hal.Tests/UriBuilderTests.cs
@@ -161,5 +161,31 @@ namespace WebApi.Hal.Tests
             // assert
             Assert.Equal("Beer", link.Title);
         }
+
+        [Fact]
+        public void create_link_absolute_uri_encode_space()
+        {
+            // arrange
+            var templatedLink = new Link("somerel", "http://localhost/beers/{path}");
+
+            // act
+            var resolvedLink = templatedLink.CreateLink(new { path = "a b" });
+
+            // assert
+            Assert.Equal("http://localhost/beers/a%20b", resolvedLink.Href);
+        }
+
+        [Fact]
+        public void create_link_relative_uri_encode_space()
+        {
+            // arrange
+            var templatedLink = new Link("somerel", "/beers/{path}");
+
+            // act
+            var resolvedLink = templatedLink.CreateLink(new { path = "a b" });
+
+            // assert
+            Assert.Equal("/beers/a%20b", resolvedLink.Href);
+        }
     }
 }

--- a/WebApi.Hal/Link.cs
+++ b/WebApi.Hal/Link.cs
@@ -92,7 +92,9 @@ namespace WebApi.Hal
             var clone = Clone();
 
             clone.Rel = newRel;
-            clone.Href = CreateUri(parameters).ToString();
+
+            var uri = CreateUri(parameters);
+            clone.Href = uri.IsAbsoluteUri ? uri.AbsoluteUri : uri.OriginalString;
 
             return clone;
         }


### PR DESCRIPTION
Handles both absolute and relative `URI`s.

Fix #132 