### PR TITLE
Empty resource list

### DIFF
--- a/WebApi.Hal.Tests/HalResourceMixedContentTest.cs
+++ b/WebApi.Hal.Tests/HalResourceMixedContentTest.cs
@@ -26,13 +26,13 @@ namespace WebApi.Hal.Tests
         {
             resource = new OrganisationWithPeopleDetailRepresentation(1, "Org Name")
             {
-                Boss = new Boss(2, "Eunice PHB", 1, true)
-            };
-            resource.People = new List<Person>
-            {
-                new Person(3, "Dilbert", 1),
-                new Person(4, "Wally", 1),
-                new Person(5, "Alice", 1)
+                Boss = new Boss(2, "Eunice PHB", 1, true),
+                People = new List<Person>
+                {
+                    new Person(3, "Dilbert", 1),
+                    new Person(4, "Wally", 1),
+                    new Person(5, "Alice", 1)
+                }
             };
         }
 
@@ -52,6 +52,61 @@ namespace WebApi.Hal.Tests
 
                 // assert
                 this.Assent(serialisedResult);
+            }
+        }
+
+        [Fact]
+        public void peopledetail_non_empty_resource_list_get_json_test()
+        {
+            // arrange
+            var resourceWithResourceList = new OrganisationWithPeopleDetailRepresentation(1, "Org Name")
+            {
+                Boss = new Boss(2, "Eunice PHB", 1, true),
+                People = new ResourceList<Person>("person")
+                {
+                    new Person(3, "Dilbert", 1),
+                    new Person(4, "Wally", 1),
+                    new Person(5, "Alice", 1)
+                }
+            };
+
+            var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+
+            // act
+            using (var stream = new StringWriter())
+            {
+                mediaFormatter.WriteObject(stream, resourceWithResourceList);
+
+                var serializedResult = stream.ToString();
+
+                // assert
+                this.Assent(serializedResult);
+            }
+        }
+
+        [Fact]
+        public void peopledetail_empty_resource_list_get_json_test()
+        {
+            // arrange
+            var emptyResource = new OrganisationWithPeopleDetailRepresentation(1, "Org Name")
+            {
+                Boss = new Boss(2, "Eunice PHB", 1, true),
+                People = new ResourceList<Person>("person")
+            };
+
+            var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+
+            // act
+            using (var stream = new StringWriter())
+            {
+                mediaFormatter.WriteObject(stream, emptyResource);
+
+                var serializedResult = stream.ToString();
+
+                // assert
+                this.Assent(serializedResult);
             }
         }
 
@@ -102,7 +157,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));
@@ -154,7 +209,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));
@@ -214,7 +269,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));
@@ -224,7 +279,7 @@ namespace WebApi.Hal.Tests
                 var org = obj.Model as OrganisationWithPeopleDetailRepresentation;
                 Assert.NotNull(org);
                 Assert.NotNull(org.Boss);
-                Assert.Equal(1, org.People.Count);
+                Assert.Single(org.People);
                 Assert.Equal(1, org.Boss.Links.Count);
             }
         }
@@ -269,7 +324,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));
@@ -314,7 +369,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));
@@ -373,7 +428,7 @@ namespace WebApi.Hal.Tests
                 var obj = await mediaFormatter.ReadAsync(new Microsoft.AspNetCore.Mvc.Formatters.InputFormatterContext(
                     context,
                     type.ToString(),
-                    new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary(),
+                    new ModelStateDictionary(),
                     CreateDefaultProvider().GetMetadataForType(type),
                     (s, encoding) => new StreamReader(s, encoding)
                     ));

--- a/WebApi.Hal.Tests/HalResourceMixedContentTest.peopledetail_empty_resource_list_get_json_test.approved.txt
+++ b/WebApi.Hal.Tests/HalResourceMixedContentTest.peopledetail_empty_resource_list_get_json_test.approved.txt
@@ -1,0 +1,29 @@
+﻿{
+  "Id": 1,
+  "Name": "Org Name",
+  "_links": {
+    "self": {
+      "href": "/api/organisations/1"
+    },
+    "people": {
+      "href": "/api/organisations/1/people"
+    },
+    "boss": {
+      "href": "/api/organisations/1/boss"
+    }
+  },
+  "_embedded": {
+    "person": [],
+    "boss": {
+      "HasPointyHair": true,
+      "Id": 2,
+      "Name": "Eunice PHB",
+      "OrganisationId": 1,
+      "_links": {
+        "self": {
+          "href": "/api/organisations/1/boss"
+        }
+      }
+    }
+  }
+}

--- a/WebApi.Hal.Tests/HalResourceMixedContentTest.peopledetail_non_empty_resource_list_get_json_test.approved.txt
+++ b/WebApi.Hal.Tests/HalResourceMixedContentTest.peopledetail_non_empty_resource_list_get_json_test.approved.txt
@@ -1,0 +1,71 @@
+﻿{
+  "Id": 1,
+  "Name": "Org Name",
+  "_links": {
+    "self": {
+      "href": "/api/organisations/1"
+    },
+    "people": {
+      "href": "/api/organisations/1/people"
+    },
+    "person": [
+      {
+        "href": "/api/organisations/1/people/3"
+      },
+      {
+        "href": "/api/organisations/1/people/4"
+      },
+      {
+        "href": "/api/organisations/1/people/5"
+      }
+    ],
+    "boss": {
+      "href": "/api/organisations/1/boss"
+    }
+  },
+  "_embedded": {
+    "person": [
+      {
+        "Id": 3,
+        "Name": "Dilbert",
+        "OrganisationId": 1,
+        "_links": {
+          "self": {
+            "href": "/api/organisations/1/people/3"
+          }
+        }
+      },
+      {
+        "Id": 4,
+        "Name": "Wally",
+        "OrganisationId": 1,
+        "_links": {
+          "self": {
+            "href": "/api/organisations/1/people/4"
+          }
+        }
+      },
+      {
+        "Id": 5,
+        "Name": "Alice",
+        "OrganisationId": 1,
+        "_links": {
+          "self": {
+            "href": "/api/organisations/1/people/5"
+          }
+        }
+      }
+    ],
+    "boss": {
+      "HasPointyHair": true,
+      "Id": 2,
+      "Name": "Eunice PHB",
+      "OrganisationId": 1,
+      "_links": {
+        "self": {
+          "href": "/api/organisations/1/boss"
+        }
+      }
+    }
+  }
+}

--- a/WebApi.Hal/EmbeddedResource.cs
+++ b/WebApi.Hal/EmbeddedResource.cs
@@ -7,5 +7,6 @@ namespace WebApi.Hal
     {
         public bool IsSourceAnArray { get; set; }
         public IList<IResource> Resources { get; private set; } = new List<IResource>();
+        public string RelationName { get; set; }
     }
 }

--- a/WebApi.Hal/IResourceList.cs
+++ b/WebApi.Hal/IResourceList.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections;
+
+namespace WebApi.Hal
+{
+    public interface IResourceList : IEnumerable
+    {
+        string RelationName { get; }
+    }
+}

--- a/WebApi.Hal/JsonConverters/EmbeddedResourceConverter.cs
+++ b/WebApi.Hal/JsonConverters/EmbeddedResourceConverter.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
+using System.Linq;
 using Newtonsoft.Json;
-using WebApi.Hal.Interfaces;
 
 namespace WebApi.Hal.JsonConverters
 {
@@ -11,13 +10,12 @@ namespace WebApi.Hal.JsonConverters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var resourceList = (IList<EmbeddedResource>)value;
-            if (resourceList.Count == 0) return;
-
+           
             writer.WriteStartObject();
 
             foreach (var rel in resourceList)
             {
-                writer.WritePropertyName(NormalizeRel(rel.Resources[0]));
+                writer.WritePropertyName(NormalizeRel(rel));
                 if (rel.IsSourceAnArray)
                     writer.WriteStartArray();
                 foreach (var res in rel.Resources)
@@ -28,11 +26,10 @@ namespace WebApi.Hal.JsonConverters
             writer.WriteEndObject();
         }
 
-        private static string NormalizeRel(IResource res)
-        {
-            if (!string.IsNullOrEmpty(res.Rel)) return res.Rel;
-            return "unknownRel-" + res.GetType().Name;
-        }
+        private static string NormalizeRel(EmbeddedResource relation) =>
+            !string.IsNullOrEmpty(relation.RelationName)
+                ? relation.RelationName
+                : $"unknownRel-{relation.Resources.FirstOrDefault()?.GetType().Name ?? string.Empty}";
 
         public override bool CanRead => false;
 

--- a/WebApi.Hal/ResourceList.cs
+++ b/WebApi.Hal/ResourceList.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using WebApi.Hal.Interfaces;
+
+namespace WebApi.Hal
+{
+    public class ResourceList<TResource> : List<TResource>, IResourceList where TResource : IResource
+    {
+        public ResourceList(string relationName) : this(relationName, new TResource[0])
+        {
+        }
+
+        public ResourceList(string relationName, IEnumerable<TResource> resources) : base(resources)
+        {
+            RelationName = relationName;
+        }
+
+        public string RelationName { get; }
+    }
+}


### PR DESCRIPTION
Fixes #131 
Current implementation has no possibility to inform front end that resource collection was queried but result is empty list. The result is undefined in the case. 
Following interface gives a possibility to mark empty collection with relation name

` public interface IResourceList : IEnumerable
    {
        string RelationName { get; }
    }`

Default implementation is also presented in to WebApi.Hal.ResourceList and used in unit tests