### PR TITLE
Continuation with updates of PR 156

### DIFF
--- a/WebApi.Hal.Build/WebApi.Hal.Commons.props
+++ b/WebApi.Hal.Build/WebApi.Hal.Commons.props
@@ -6,7 +6,7 @@
 
     <Company>Jake Ginnivan</Company>
     <Description>Enabled Hypermedia support in Asp.net Web API using the HAL mediatype</Description>
-    <Copyright>Copyright © Jake Ginnvan 2012</Copyright>
+    <Copyright>Copyright © Jake Ginnvan 2020</Copyright>
     <PackageProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</PackageProjectUrl>
     <PackageLicense>$(PackageProjectUrl)/blob/master/LICENSE.md</PackageLicense>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>

--- a/WebApi.Hal.Build/WebApi.Hal.Commons.props
+++ b/WebApi.Hal.Build/WebApi.Hal.Commons.props
@@ -8,7 +8,7 @@
     <Description>Enabled Hypermedia support in Asp.net Web API using the HAL mediatype</Description>
     <Copyright>Copyright © Jake Ginnvan 2012</Copyright>
     <PackageProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</PackageProjectUrl>
-    <PackageLicenseUrl>$(PackageProjectUrl)/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicense>$(PackageProjectUrl)/blob/master/LICENSE.md</PackageLicense>
     <PackageReleaseNotes>$(PackageProjectUrl)/releases</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 

--- a/WebApi.Hal.Tests/HalResourceListTests.cs
+++ b/WebApi.Hal.Tests/HalResourceListTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using Assent;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApi.Hal.Tests.Representations;
 using Xunit;
@@ -54,7 +55,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())
@@ -73,7 +74,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
             var content = new StringContent(string.Empty);
             var type = oneitemrepresentation.GetType();
 

--- a/WebApi.Hal.Tests/HalResourceMixedContentTest.cs
+++ b/WebApi.Hal.Tests/HalResourceMixedContentTest.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 using Assent;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using Newtonsoft.Json;
@@ -41,7 +39,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())
@@ -71,7 +69,7 @@ namespace WebApi.Hal.Tests
             };
 
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())
@@ -96,7 +94,7 @@ namespace WebApi.Hal.Tests
             };
 
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())
@@ -137,7 +135,7 @@ namespace WebApi.Hal.Tests
                 new JsonSerializerSettings { Formatting = Formatting.Indented },
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
-                new MvcOptions(), new MvcJsonOptions());
+                new MvcOptions(), new MvcNewtonsoftJsonOptions());
 
             var type = typeof(OrganisationWithPeopleDetailRepresentation);
             const string json = @"
@@ -181,7 +179,7 @@ namespace WebApi.Hal.Tests
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
                 new MvcOptions(), 
-                new MvcJsonOptions());
+                new MvcNewtonsoftJsonOptions());
 
             var type = typeof(OrganisationWithPeopleRepresentation);
             const string json = @"
@@ -243,7 +241,7 @@ namespace WebApi.Hal.Tests
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
                 new MvcOptions(), 
-                new MvcJsonOptions());
+                new MvcNewtonsoftJsonOptions());
 
             var type = typeof(OrganisationWithPeopleDetailRepresentation);
             const string json = @"
@@ -294,7 +292,7 @@ namespace WebApi.Hal.Tests
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
                 new MvcOptions(), 
-                new MvcJsonOptions());
+                new MvcNewtonsoftJsonOptions());
 
             var type = typeof(OrganisationWithPeopleDetailRepresentation);
             const string json = @"
@@ -349,7 +347,7 @@ namespace WebApi.Hal.Tests
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
                 new MvcOptions(), 
-                new MvcJsonOptions());
+                new MvcNewtonsoftJsonOptions());
 
             var type = typeof(OrganisationWithPeopleDetailRepresentation);
             const string json = @"
@@ -402,7 +400,7 @@ namespace WebApi.Hal.Tests
                 ArrayPool<char>.Shared,
                 new DefaultObjectPoolProvider(),
                 new MvcOptions(), 
-                new MvcJsonOptions());
+                new MvcNewtonsoftJsonOptions());
 
             var type = typeof(MySimpleList);
             const string json = @"
@@ -448,16 +446,9 @@ namespace WebApi.Hal.Tests
             }
         }
 
-        public static IModelMetadataProvider CreateDefaultProvider()
+        public static ModelMetadataProvider CreateDefaultProvider()
         {
-            var detailsProviders = new IMetadataDetailsProvider[]
-            {
-                new DefaultBindingMetadataProvider(),
-                new DefaultValidationMetadataProvider()
-            };
-
-            var compositeDetailsProvider = new DefaultCompositeMetadataDetailsProvider(detailsProviders);
-            return new DefaultModelMetadataProvider(compositeDetailsProvider);
+            return new EmptyModelMetadataProvider();
         }
     }
 }

--- a/WebApi.Hal.Tests/HalResourceTest.cs
+++ b/WebApi.Hal.Tests/HalResourceTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers;
 using System.IO;
 using Assent;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApi.Hal.Tests.Representations;
 using Xunit;
@@ -21,7 +22,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())
@@ -40,7 +41,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
             var resourceWithAppPath = new OrganisationWithAppPathRepresentation(1, "Org Name");
 
             // act
@@ -60,7 +61,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
             var resourceWithAppPath = new OrganisationWithNoHrefRepresentation(1, "Org Name");
 
             // act
@@ -80,7 +81,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
             var resourceWithAppPath = new OrganisationWithLinkTitleRepresentation(1, "Org Name");
 
             // act

--- a/WebApi.Hal.Tests/HalResourceWithPeopleTest.cs
+++ b/WebApi.Hal.Tests/HalResourceWithPeopleTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers;
 using System.IO;
 using Assent;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApi.Hal.Tests.Representations;
 using Xunit;
@@ -21,7 +22,7 @@ namespace WebApi.Hal.Tests
         {
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions());
 
             // act
             using (var stream = new StringWriter())

--- a/WebApi.Hal.Tests/HypermediaContainerTests.cs
+++ b/WebApi.Hal.Tests/HypermediaContainerTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using Assent;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApi.Hal.Tests.HypermediaAppenders;
 using WebApi.Hal.Tests.Representations;
@@ -29,7 +30,7 @@ namespace WebApi.Hal.Tests
 
             // arrange
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, config);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions(), config);
 
             // act
             using (var stream = new StringWriter())

--- a/WebApi.Hal.Tests/ResolvingHalResourceTest.cs
+++ b/WebApi.Hal.Tests/ResolvingHalResourceTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Buffers;
 using System.IO;
 using Assent;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApi.Hal.Tests.HypermediaAppenders;
 using WebApi.Hal.Tests.Representations;
@@ -51,7 +52,7 @@ namespace WebApi.Hal.Tests
 
             var config = builder.Build();
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, config);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions(), config);
 
             // act
             using (var stream = new StringWriter())
@@ -72,7 +73,7 @@ namespace WebApi.Hal.Tests
 			var builder = Hypermedia.CreateBuilder();
 			var config = builder.Build();
             var mediaFormatter = new JsonHalMediaTypeOutputFormatter(
-                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, config);
+                new JsonSerializerSettings { Formatting = Formatting.Indented }, ArrayPool<char>.Shared, new MvcOptions(), config);
 
             // act
             using (var stream = new StringWriter())

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>3.0.0-pre-1</Version>
     <Authors>Jake Ginnivan, DotNetMedia Organizaion</Authors>
     <Copyright>Copyright © Jake Ginnvan 2017</Copyright>
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Assent" Version="1.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+    <PackageReference Include="Assent" Version="1.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Assent" Version="1.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+    <PackageReference Include="Assent" Version="1.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/WebApi.Hal.Web/FormattersMvcOptionsSetup.cs
+++ b/WebApi.Hal.Web/FormattersMvcOptionsSetup.cs
@@ -14,11 +14,11 @@ namespace WebApi.Hal.Web
         private readonly JsonSerializerSettings _jsonSerializerSettings;
         private readonly ArrayPool<char> _charPool;
         private readonly ObjectPoolProvider _objectPoolProvider;
-        private readonly MvcJsonOptions _mvcJsonOptions;
+        private readonly MvcNewtonsoftJsonOptions _mvcJsonOptions;
 
         public FormattersMvcOptionsSetup(
             ILoggerFactory loggerFactory,
-            IOptions<MvcJsonOptions> jsonOptions,
+            IOptions<MvcNewtonsoftJsonOptions> jsonOptions,
             ArrayPool<char> charPool,
             ObjectPoolProvider objectPoolProvider)
         {
@@ -37,7 +37,7 @@ namespace WebApi.Hal.Web
         public void Configure(MvcOptions options)
         {
             options.OutputFormatters.Add(new XmlHalMediaTypeOutputFormatter());
-            options.OutputFormatters.Add(new JsonHalMediaTypeOutputFormatter(_jsonSerializerSettings, _charPool));
+            options.OutputFormatters.Add(new JsonHalMediaTypeOutputFormatter(_jsonSerializerSettings, _charPool, options));
 
             // Register JsonPatchInputFormatter before JsonInputFormatter, otherwise
             // JsonInputFormatter would consume "application/json-patch+json" requests

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.9" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>WebApi.Hal.Web</AssemblyName>
   </PropertyGroup>
 
@@ -12,10 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApi.Hal.sln
+++ b/WebApi.Hal.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Licence.md = Licence.md
 		README.md = README.md
 		Readme.txt = Readme.txt
+		WebApi.Hal.Build\WebApi.Hal.Commons.props = WebApi.Hal.Build\WebApi.Hal.Commons.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.Hal.Web", "WebApi.Hal.Web\WebApi.Hal.Web.csproj", "{29ADB701-A036-4195-8478-2FE393CC7A74}"

--- a/WebApi.Hal.sln
+++ b/WebApi.Hal.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.Hal", "WebApi.Hal\WebApi.Hal.csproj", "{8A01C801-D7E6-4ACB-A843-7C3EFB7833F7}"
 EndProject

--- a/WebApi.Hal/JsonHalMediaTypeInputFormatter.cs
+++ b/WebApi.Hal/JsonHalMediaTypeInputFormatter.cs
@@ -9,13 +9,13 @@ using WebApi.Hal.JsonConverters;
 
 namespace WebApi.Hal
 {
-    public class JsonHalMediaTypeInputFormatter : JsonInputFormatter
+    public class JsonHalMediaTypeInputFormatter : NewtonsoftJsonInputFormatter
     {
         private readonly LinksConverter _linksConverter = new LinksConverter();
         private readonly ResourceConverter _resourceConverter;
         private readonly EmbeddedResourceConverter _embeddedResourceConverter = new EmbeddedResourceConverter();
 
-        public JsonHalMediaTypeInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, IHypermediaResolver hypermediaResolver, MvcOptions mvcOptions, MvcJsonOptions mvcJsonOptions) 
+        public JsonHalMediaTypeInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, IHypermediaResolver hypermediaResolver, MvcOptions mvcOptions, MvcNewtonsoftJsonOptions mvcJsonOptions) 
             : base(logger, serializerSettings, charPool, objectPoolProvider, mvcOptions, mvcJsonOptions)
         {
             if (hypermediaResolver == null)
@@ -27,7 +27,7 @@ namespace WebApi.Hal
             Initialize();
         }
 
-        public JsonHalMediaTypeInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, MvcOptions mvcOptions, MvcJsonOptions mvcJsonOptions) 
+        public JsonHalMediaTypeInputFormatter(ILogger logger, JsonSerializerSettings serializerSettings, ArrayPool<char> charPool, ObjectPoolProvider objectPoolProvider, MvcOptions mvcOptions, MvcNewtonsoftJsonOptions mvcJsonOptions) 
             : base(logger, serializerSettings, charPool, objectPoolProvider, mvcOptions, mvcJsonOptions)
         {
             _resourceConverter = new ResourceConverter(SerializerSettings);

--- a/WebApi.Hal/JsonHalMediaTypeOutputFormatter.cs
+++ b/WebApi.Hal/JsonHalMediaTypeOutputFormatter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers;
-using System.Reflection;
+using System.IO;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
@@ -8,7 +9,7 @@ using WebApi.Hal.JsonConverters;
 
 namespace WebApi.Hal
 {
-    public class JsonHalMediaTypeOutputFormatter : JsonOutputFormatter
+    public class JsonHalMediaTypeOutputFormatter : NewtonsoftJsonOutputFormatter
     {
         private const string _mediaTypeHeaderValueName = "application/hal+json";
 
@@ -19,9 +20,10 @@ namespace WebApi.Hal
 
         public JsonHalMediaTypeOutputFormatter(
             JsonSerializerSettings serializerSettings, 
-            ArrayPool<char> charPool, 
+            ArrayPool<char> charPool,
+            MvcOptions mvcOptions,
             IHypermediaResolver hypermediaResolver) : 
-            base(serializerSettings, charPool)
+            base(serializerSettings, charPool, mvcOptions)
         {
             if (hypermediaResolver == null)
             {
@@ -34,11 +36,17 @@ namespace WebApi.Hal
 
         public JsonHalMediaTypeOutputFormatter(
             JsonSerializerSettings serializerSettings, 
-            ArrayPool<char> charPool) :
-            base(serializerSettings, charPool)
+            ArrayPool<char> charPool,
+            MvcOptions mvcOptions) :
+            base(serializerSettings, charPool, mvcOptions)
         {
             _resourceConverter = new ResourceConverter(SerializerSettings);
             Initialize();
+        }
+
+        public void WriteObject(TextWriter stream, object value)
+        {
+            CreateJsonSerializer().Serialize(stream, value);
         }
 
         private void Initialize()

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -5,14 +5,14 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Version>3.1.0</Version>
-+    <PackageVersion>3.1.0</PackageVersion>
+    <PackageVersion>3.1.0</PackageVersion>
     <Copyright>Copyright © Jake Ginnivan 2018</Copyright>
     <Description>Adds support for the Hal Media Type (and Hypermedia) to Asp.net</Description>
     <ProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</ProjectUrl>
     <IsPackable>true</IsPackable>
     <PackageReleaseNotes>3.10 updates to support multithreaded usage
-+    3.0.0 first .net standard release
-+    </PackageReleaseNotes>
+    3.0.0 first .net standard release
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Version>4.0.0</Version>
     <PackageVersion>4.0.0</PackageVersion>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Copyright>Copyright © Jake Ginnivan 2020</Copyright>
     <Description>Adds support for the Hal Media Type (and Hypermedia) to Asp.net</Description>
     <ProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</ProjectUrl>
@@ -19,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -4,15 +4,13 @@
   
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <Version>3.1.0</Version>
-    <PackageVersion>3.1.0</PackageVersion>
+    <Version>3.2.0</Version>
+    <PackageVersion>3.2.0</PackageVersion>
     <Copyright>Copyright © Jake Ginnivan 2018</Copyright>
     <Description>Adds support for the Hal Media Type (and Hypermedia) to Asp.net</Description>
     <ProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</ProjectUrl>
     <IsPackable>true</IsPackable>
-    <PackageReleaseNotes>3.10 updates to support multithreaded usage
-    3.0.0 first .net standard release
-    </PackageReleaseNotes>
+    <PackageReleaseNotes>3.20 update to support .net core 3.1</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Version>3.1.0</Version>
 +    <PackageVersion>3.1.0</PackageVersion>
     <Copyright>Copyright © Jake Ginnivan 2018</Copyright>
@@ -16,9 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.2" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>

--- a/WebApi.Hal/XmlHalMediaTypeOutputFormatter.cs
+++ b/WebApi.Hal/XmlHalMediaTypeOutputFormatter.cs
@@ -58,7 +58,7 @@ namespace WebApi.Hal
             var settings = new XmlWriterSettings
             {
                 Indent = true,
-                Encoding = Encoding.UTF8
+                Encoding = writer.Encoding
             };
             using (var xmlWriter = XmlWriter.Create(writer, settings))
             {
@@ -70,7 +70,8 @@ namespace WebApi.Hal
         private void Initialize()
         {
             SupportedMediaTypes.Add(new MediaTypeHeaderValue(_mediaTypeHeaderValueName));
-        }
+            SupportedEncodings.Add(Encoding.UTF8);
+    }
         
         /// <summary>
         /// ReadHalResource will

--- a/WebApi.Hal/XmlHalMediaTypeOutputFormatter.cs
+++ b/WebApi.Hal/XmlHalMediaTypeOutputFormatter.cs
@@ -14,7 +14,7 @@ using WebApi.Hal.Interfaces;
 
 namespace WebApi.Hal
 {
-    public class XmlHalMediaTypeOutputFormatter : OutputFormatter
+    public class XmlHalMediaTypeOutputFormatter : TextOutputFormatter
     {
         private const string _mediaTypeHeaderValueName = "application/hal+xml";
         
@@ -23,7 +23,7 @@ namespace WebApi.Hal
             Initialize();
         }
         
-        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
         {
             if (context == null)
             {
@@ -32,9 +32,8 @@ namespace WebApi.Hal
             
             var response = context.HttpContext.Response;
             var contentType = context.ContentType;
-            var encoding = (contentType.HasValue ? (Encoding)Enum.Parse(typeof(Encoding), contentType.Value) : null) ?? Encoding.UTF8;
             var memoryStream = new MemoryStream();
-            using (var textWriter = context.WriterFactory(memoryStream, encoding))
+            using (var textWriter = context.WriterFactory(memoryStream, selectedEncoding))
             {
                 WriteObject(textWriter, context.Object);
                 await textWriter.FlushAsync();


### PR DESCRIPTION
Fixed merge conflicts with the original PR 156 by @marner2. The plan is a dotnet core 3.1 version 4.0 with no new features. Dotnet framework users can continue to use version 3.1. This will remain the case, barring unforeseen maintenance work needed, until dotnet 5 is released and stable and we can move to netstandard2.1 and support both .net core and .net framework users again. 