### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[18.6.0,)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Assent" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>3.0.0-pre-1</Version>
     <Authors>Jake Ginnivan, DotNetMedia Organizaion</Authors>
     <Copyright>Copyright © Jake Ginnvan 2017</Copyright>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Assent" Version="3.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[18.6.0,)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[18.7.0,)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
+++ b/WebApi.Hal.Tests/WebApi.Hal.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Assent" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/WebApi.Hal.Web/Program.cs
+++ b/WebApi.Hal.Web/Program.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace WebApi.Hal.Web
 {
@@ -7,11 +7,14 @@ namespace WebApi.Hal.Web
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/WebApi.Hal.Web/Startup.cs
+++ b/WebApi.Hal.Web/Startup.cs
@@ -8,8 +8,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.Swagger;
+using Microsoft.OpenApi;
 using WebApi.Hal.Web.Data;
 
 namespace WebApi.Hal.Web

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[8.0.20,9.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[8.0.20,9.0.0)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="[8.1.4,9.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.8,11.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.8,11.0.0)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.1,11.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.9,)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.9,)" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.3,11.0.0)" />
   </ItemGroup>
 

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.8,)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.8,)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.9,)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.9,)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.3,11.0.0)" />
   </ItemGroup>
 

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.8,)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.8,)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.1,11.0.0)" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.3,11.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>WebApi.Hal.Web</AssemblyName>
   </PropertyGroup>
 

--- a/WebApi.Hal.Web/WebApi.Hal.Web.csproj
+++ b/WebApi.Hal.Web/WebApi.Hal.Web.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.8,11.0.0)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.8,11.0.0)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[10.0.8,)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="[10.0.8,)" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="[10.2.1,11.0.0)" />
   </ItemGroup>
 

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -34,11 +34,11 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.8,11.0.0)" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,11.0.0)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.10" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.8,)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="[4.7.0,)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.10,)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.10,)" />
   </ItemGroup>
 
 </Project>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -37,8 +37,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.9,)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="[4.7.0,)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.10,)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.10,)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.11,)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.11,)" />
   </ItemGroup>
 
 </Project>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -3,7 +3,7 @@
   <Import Project=".\..\WebApi.Hal.Build\WebApi.Hal.Commons.props" />
   
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>8.0.0</Version>
     <PackageVersion>8.0.0</PackageVersion>
     <Copyright>Copyright © Jake Ginnivan 2020</Copyright>
@@ -38,7 +38,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[8.0.0, 9.0.0)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -34,7 +34,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.8,)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.9,)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="[4.7.0,)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.10,)" />

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -4,13 +4,14 @@
   
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>8.0.0</Version>
-    <PackageVersion>8.0.0</PackageVersion>
+    <Version>10.0.0</Version>
+    <PackageVersion>10.0.0</PackageVersion>
     <Copyright>Copyright © Jake Ginnivan 2020</Copyright>
     <Description>Adds support for the Hal Media Type (and Hypermedia) to Asp.net</Description>
     <ProjectUrl>https://github.com/JakeGinnivan/WebApi.Hal</ProjectUrl>
     <IsPackable>true</IsPackable>
     <PackageReleaseNotes>
+      10.0.0 update to support .NET 10.0
       8.0.0 update to support .NET 8.0
       4.0.1 ability to mark a link-rel as multi-link to ensure that it always serialzies to an array, even if there's only one link at runtime
       4.0.0 update to support .net core 3.1

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -36,8 +36,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.8,11.0.0)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,11.0.0)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.10" />
   </ItemGroup>
 
 </Project>

--- a/WebApi.Hal/WebApi.Hal.csproj
+++ b/WebApi.Hal/WebApi.Hal.csproj
@@ -33,9 +33,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[8.0.20,9.0.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[10.0.8,11.0.0)" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[8.0.0, 9.0.0)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[10.0.300,11.0.0)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Upgrade every package in sight to the latest version

It's that time of year again.

As for the web sample program Program.cs: I noticed that you were using the identical sample code to that at https://learn.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-10.0&tabs=visual-studio#hostbuilder-replaces-webhostbuilder, so I grabbed the newer sample code from the same page.